### PR TITLE
Script start in PRODUCTION environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 On `master` will deploy a build to Netlify, meaning it will be live on our domain within 2-3 minutes
 
 
+### `npm start`
+
+Runs the app in the "PRODUCTION" mode.<br />
+Open [http://localhost:5000](http://localhost:5000) to view it in the browser.
+
+The page will NOT reload if you make edits.<br />
+You will also see any lint errors in the console.
+
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 On `master` will deploy a build to Netlify, meaning it will be live on our domain within 2-3 minutes
 
 
-### `npm start`
+### `npm start:production`
 
 Runs the app in the "PRODUCTION" mode.<br />
 Open [http://localhost:5000](http://localhost:5000) to view it in the browser.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "start:production": "yarn build && serve -s build"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/Mixpanel.js
+++ b/src/Mixpanel.js
@@ -1,22 +1,21 @@
 import mixpanel from 'mixpanel-browser';
 mixpanel.init('741a30e4e4ffc18f1e224dadcde34cc7');
 
-let env_check = process.env.NODE_ENV === 'production';
-//let env_check = process.env.NODE_ENV !== 'production';
+let currentEnvironment = process.env.NODE_ENV === 'production';
 
 let actions = {
   identify: (id) => {
-    if (env_check) mixpanel.identify(id);
+    if (currentEnvironment) mixpanel.identify(id);
   },
   alias: (id) => {
-    if (env_check) mixpanel.alias(id);
+    if (currentEnvironment) mixpanel.alias(id);
   },
   track: (name, props) => {
-    if (env_check) mixpanel.track(name, props);
+    if (currentEnvironment) mixpanel.track(name, props);
   },
   people: {
     set: (props) => {
-      if (env_check) mixpanel.people.set(props);
+      if (currentEnvironment) mixpanel.people.set(props);
     },
   },
 };


### PR DESCRIPTION
This PR introduces `script start` in PRODUCTION environment and README update

Use this to run Production mode:
```
### `npm start:production`

Runs the app in the "PRODUCTION" mode.<br />
Open [http://localhost:5000](http://localhost:5000) to view it in the browser.

The page will NOT reload if you make edits.<br />
You will also see any lint errors in the console.
```