### PR TITLE
Redirect referred user after accepting invitation

### DIFF
--- a/src/components/views/Referral/AcceptReferral.js
+++ b/src/components/views/Referral/AcceptReferral.js
@@ -32,7 +32,7 @@ export default class AcceptReferral extends Component {
         Mixpanel.track('PM.c Signup: Referral accepted');
         // Success response - redirect and set tracker
         Mixpanel.track(`PM.c Signup: Referral accepted: ${referralLink}`);
-        window.location.href = '/home';
+        window.location.href = 'www.productmastery.co';
       })
       .catch(() => {
         this.setState({ error: 'Link is not valid' });


### PR DESCRIPTION
Redirect referred user to `www.productmastery.co` after accepting the invitation.